### PR TITLE
Changed if else snippet tab trigger to contain no space

### DIFF
--- a/Snippets/ifelse.sublime-snippet
+++ b/Snippets/ifelse.sublime-snippet
@@ -6,7 +6,7 @@
 	${3:what to do else}
 {% endif %}
 ]]></content>
-<tabTrigger>if else</tabTrigger>
+<tabTrigger>ifelse</tabTrigger>
 <description>liquid if else</description>
 <scope>text.html</scope>
 </snippet>


### PR DESCRIPTION
Removing the space enabled the tab trigger to work. I'm on the latest version of sublime 3.