### PR TITLE
Embed JSON syntax between {% schema %} and {% endschema %}

### DIFF
--- a/Syntaxes/Liquid Tag.sublime-syntax
+++ b/Syntaxes/Liquid Tag.sublime-syntax
@@ -15,7 +15,7 @@ contexts:
       scope: keyword.operator.logical.liquid
     - match: '\b(and|or|not|contains|in|by|offset)\b'
       scope: keyword.operator.liquid
-    - match: '\b(include|endcapture|capture|assign)\b'
+    - match: '\b(include|endcapture|capture|assign|schema|endschema)\b'
       scope: keyword.control.liquid
     - match: '='
       scope: keyword.operator.assignment.liquid

--- a/Syntaxes/Liquid-HTML.sublime-syntax
+++ b/Syntaxes/Liquid-HTML.sublime-syntax
@@ -28,6 +28,14 @@ contexts:
               scope: punctuation.definition.comment.end.liquid
               pop: true
 
+        - match: '{%-?\s*schema\s*-?%}'
+          scope: schema.liquid punctuation.section.schema.begin.liquid
+          embed: scope:source.json
+          embed_scope: schema.liquid
+          escape: '{%-?\s*endschema\s*-?%}'
+          escape_captures:
+            0: schema.liquid punctuation.section.schema.end.liquid
+
         - match: '{{'
           scope: punctuation.definition.object.begin.liquid
           embed: scope:meta.object.liquid


### PR DESCRIPTION
Shopify uses the `{% schema %}` tag to define the "schema" of a theme section.
The schema is a JSON document that describes the section and its settings.
See https://help.shopify.com/en/themes/development/sections#using-section-schema-tags