### PR TITLE
{% elsif %}, {% case %}, and {% when %}

### DIFF
--- a/Syntaxes/Liquid Tag.sublime-syntax
+++ b/Syntaxes/Liquid Tag.sublime-syntax
@@ -9,7 +9,7 @@ hidden: true
 
 contexts:
   main:
-    - match: '\b(if|else|elsif|endif|for|endfor|unless|endunless)\b'
+    - match: '\b(if|else|elsif|endif|for|endfor|unless|endunless|case|when|endcase)\b'
       scope: keyword.control.flow.liquid
     - match: '(!=|==|<=|>=|<|>)'
       scope: keyword.operator.logical.liquid

--- a/Syntaxes/Liquid Tag.sublime-syntax
+++ b/Syntaxes/Liquid Tag.sublime-syntax
@@ -19,7 +19,7 @@ contexts:
       scope: keyword.control.liquid
     - match: '='
       scope: keyword.operator.assignment.liquid
-    - match: 'blank|empty|true|false|nil'
+    - match: '\b(blank|empty|true|false|nil)\b'
       scope: constant.language.liquid
 
     - include: scope:meta.object.liquid

--- a/Syntaxes/Liquid Tag.sublime-syntax
+++ b/Syntaxes/Liquid Tag.sublime-syntax
@@ -9,7 +9,7 @@ hidden: true
 
 contexts:
   main:
-    - match: '\b(if|else|endif|for|endfor|unless|endunless)\b'
+    - match: '\b(if|else|elsif|endif|for|endfor|unless|endunless)\b'
       scope: keyword.control.flow.liquid
     - match: '(!=|==|<=|>=|<|>)'
       scope: keyword.operator.logical.liquid


### PR DESCRIPTION
Hi @braver,

As the title says, I added the tags `{% elsif %}`, `{% case %}`, and `{% when %}`.

I also fixed the partial highlighting of some words, like "blank" in "blanket":
![image](https://user-images.githubusercontent.com/5462433/69225429-ae85a380-0b7e-11ea-830e-d4ac3d80d585.png)

I saw that, in some situations, a tag matches even when it's not right after the `{%`.
For example, "capture" in "if object.capture":
![image](https://user-images.githubusercontent.com/5462433/69225648-08866900-0b7f-11ea-8340-a4b6c80bd70a.png)
I don't know how to fix that. I tried adding a `^` to the regex, but it didn't work.
Any idea?

Best regards,
Benoit