### PR TITLE
Add render tag

### DIFF
--- a/Snippets/render.sublime-snippet
+++ b/Snippets/render.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+<content><![CDATA[
+{% render $1 %}
+]]></content>
+<tabTrigger>render</tabTrigger>
+<description>liquid render</description>
+<scope>text.html</scope>
+</snippet>

--- a/Syntaxes/Liquid Tag.sublime-syntax
+++ b/Syntaxes/Liquid Tag.sublime-syntax
@@ -15,7 +15,7 @@ contexts:
       scope: keyword.operator.logical.liquid
     - match: '\b(and|or|not|contains|in|by|offset)\b'
       scope: keyword.operator.liquid
-    - match: '\b(include|endcapture|capture|assign)\b'
+    - match: '\b(include|render|endcapture|capture|assign)\b'
       scope: keyword.control.liquid
     - match: '='
       scope: keyword.operator.assignment.liquid


### PR DESCRIPTION
Hello! Because the {% include %} tag has been deprecated in favor of a similar tag called {% render %}, this pull request adds the render tag in, as well as the snippet for it.

More details:
https://developers.shopify.com/changelog/deprecating-the-include-liquid-tag-and-introducing-the-render-tag

By the way, do you have plans to push your most recent commits to the one on package control? They have been very useful.

Thanks for checking this PR out and having made this sublime package,
Roy
