### PR TITLE
Add optional hyphen to object interpolation punctuation scope

### DIFF
--- a/Syntaxes/Liquid.sublime-syntax
+++ b/Syntaxes/Liquid.sublime-syntax
@@ -191,11 +191,11 @@ contexts:
     - include: immediately-pop
 
   liquid-objects:
-    - match: '{{'
+    - match: '{{-?'
       scope: meta.interpolation.liquid punctuation.section.interpolation.begin.liquid
       embed: liquid-object-body
       embed_scope: meta.interpolation.liquid source.liquid
-      escape: '}}'
+      escape: '-?}}'
       escape_captures:
         0: meta.interpolation.liquid punctuation.section.interpolation.end.liquid
 

--- a/tests/syntax_test_liquid.liquid.html
+++ b/tests/syntax_test_liquid.liquid.html
@@ -630,6 +630,18 @@ div {
 |                     ^^^^^ meta.string.liquid string.quoted.double.liquid
 |                           ^^ punctuation.section.interpolation.end.liquid
 
+  {{- foo.bar | where: "foo" -}}
+| ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.liquid
+| ^^^ punctuation.section.interpolation.begin.liquid
+|     ^^^ variable.other.liquid
+|        ^ punctuation.accessor.dot.liquid
+|         ^^^ variable.other.member.liquid
+|             ^ keyword.operator.logical.pipe.liquid
+|               ^^^^^ support.function.filter.liquid
+|                    ^ punctuation.separator.key-value.liquid
+|                      ^^^^^ meta.string.liquid string.quoted.double.liquid
+|                            ^^^ punctuation.section.interpolation.end.liquid
+
   {{ 10 -10 +10 }}
 | ^^^^^^^^^^^^^^^^ meta.interpolation.liquid
 |    ^^ meta.number.integer.decimal.liquid constant.numeric.value.liquid


### PR DESCRIPTION
This just adds the optional hyphens in `{{-`, `-}}` to the punctuation scope.