### PR TITLE
Allow capitalization in variables filters, and tags

### DIFF
--- a/Syntaxes/Liquid.sublime-syntax
+++ b/Syntaxes/Liquid.sublime-syntax
@@ -418,7 +418,7 @@ contexts:
 
   liquid-filter-name:
     - meta_scope: meta.filter.liquid
-    - match: \b[a-z_-]+\b
+    - match: \b[a-zA-Z_-]+\b
       scope: support.function.filter.liquid
       pop: 1
     - include: else-pop

--- a/Syntaxes/Liquid.sublime-syntax
+++ b/Syntaxes/Liquid.sublime-syntax
@@ -9,7 +9,7 @@ version: 2
 hidden: true
 
 variables:
-  liquid_variables: \b[a-z_][0-9a-z_]*\b
+  liquid_variables: \b[a-zA-Z_][0-9a-zA-Z_]*\b
 
   jekyll_highlight_begin: (?:({%)\s*(highlight)\s+)
   jekyll_highlight_params: (?:(?:\s+(\S.*?))?\s*(%}))


### PR DESCRIPTION
Match liquid variables and filter names even if they contain uppercase characters. Resolves https://github.com/SublimeText/Liquid/issues/14.