### PR TITLE
Add `null` to null constants

### DIFF
--- a/Syntaxes/Liquid.sublime-syntax
+++ b/Syntaxes/Liquid.sublime-syntax
@@ -472,7 +472,7 @@ contexts:
 ###[ LIQUID LITERALS ]########################################################
 
   liquid-constants:
-    - match: \b(?:blank|empty|nil)\b
+    - match: \b(?:blank|empty|nil|null)\b
       scope: constant.language.null.liquid
     - match: \b(?:true|false)\b
       scope: constant.language.boolean.liquid


### PR DESCRIPTION
This just adds `null` to null constants.

Shopify’s tooling [prefers `null`](https://github.com/Shopify/theme-tools/issues/374#issuecomment-2355760058) and the Prettier plugin will automatically replace `nil` with `null`.