### PR TITLE
Add Liquid interpolation to CSS outside rules

### DIFF
--- a/Syntaxes/CSS (Liquid).sublime-syntax
+++ b/Syntaxes/CSS (Liquid).sublime-syntax
@@ -22,16 +22,27 @@ contexts:
 
   stylesheet:
     - meta_prepend: true
-    - include: scope:source.liquid#interpolations
+    - include: scope:source.liquid#liquid-tags
 
-  string-content:
+  at-keyframe-block-body:
     - meta_prepend: true
-    - include: scope:source.liquid#interpolations
+    - meta_include_prototype: false
+    - include: scope:source.liquid#liquid-tags
+
+  at-layer-name-list:
+    - meta_prepend: true
+    - meta_include_prototype: false
+    - include: scope:source.liquid#liquid-tags
 
   at-supports-group-body:
     - meta_prepend: true
     - meta_include_prototype: false
     - include: scope:source.liquid#liquid-tags
+
+  stylesheet-block-body:
+    # required until ST4174 (PR #3831)
+    - meta_prepend: true
+    - meta_include_prototype: false
 
   property-lists:
     - match: \{(?!{)
@@ -42,3 +53,7 @@ contexts:
     - meta_prepend: true
     - meta_include_prototype: false
     - include: scope:source.liquid#liquid-tags
+
+  string-content:
+    - meta_prepend: true
+    - include: scope:source.liquid#interpolations

--- a/Syntaxes/CSS (Liquid).sublime-syntax
+++ b/Syntaxes/CSS (Liquid).sublime-syntax
@@ -17,6 +17,10 @@ contexts:
     - meta_prepend: true
     - include: scope:source.liquid
 
+  stylesheet:
+    - meta_prepend: true
+    - include: scope:source.liquid#interpolations
+
   string-content:
     - meta_prepend: true
     - include: scope:source.liquid#interpolations

--- a/Syntaxes/Liquid.sublime-syntax
+++ b/Syntaxes/Liquid.sublime-syntax
@@ -474,8 +474,10 @@ contexts:
   liquid-constants:
     - match: \b(?:blank|empty|nil|null)\b
       scope: constant.language.null.liquid
-    - match: \b(?:true|false)\b
-      scope: constant.language.boolean.liquid
+    - match: \bfalse\b
+      scope: constant.language.boolean.false.liquid
+    - match: \btrue\b
+      scope: constant.language.boolean.true.liquid
 
   liquid-numbers:
     - match: ([-+])?\d+(\.)\d+\b

--- a/tests/syntax_test_jekyll.jekyll.html
+++ b/tests/syntax_test_jekyll.jekyll.html
@@ -131,7 +131,7 @@ end
 |       ^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.embedded.liquid source.liquid meta.statement.liquid
 |       ^^ punctuation.section.embedded.begin.liquid
 |          ^^ keyword.control.conditional.if.liquid
-|             ^^^^ constant.language.boolean.liquid
+|             ^^^^ constant.language.boolean.true.liquid
 |                  ^^ punctuation.section.embedded.end.liquid
 ;       font-{{family}}: "{{font}}";
 |            ^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.interpolation.liquid

--- a/tests/syntax_test_jekyll.md
+++ b/tests/syntax_test_jekyll.md
@@ -131,7 +131,7 @@ end
 |       ^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.embedded.liquid source.liquid meta.statement.liquid
 |       ^^ punctuation.section.embedded.begin.liquid
 |          ^^ keyword.control.conditional.if.liquid
-|             ^^^^ constant.language.boolean.liquid
+|             ^^^^ constant.language.boolean.true.liquid
 |                  ^^ punctuation.section.embedded.end.liquid
 ;       font-{{family}}: "{{font}}";
 |            ^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.interpolation.liquid

--- a/tests/syntax_test_liquid.liquid.html
+++ b/tests/syntax_test_liquid.liquid.html
@@ -716,6 +716,41 @@ div {
  -->
 
 <style>
+
+    {% if true %}
+|   ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|   ^^ punctuation.section.embedded.begin.liquid
+|      ^^ keyword.control.conditional.if.liquid
+|         ^^^^ constant.language.boolean.true.liquid
+|              ^^ punctuation.section.embedded.end.liquid
+
+    @keyframes {
+      {% if true %}
+|     ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^ keyword.control.conditional.if.liquid
+|           ^^^^ constant.language.boolean.true.liquid
+|                ^^ punctuation.section.embedded.end.liquid
+        
+      {% endif %}
+|     ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^^^^ keyword.control.conditional.end.liquid
+|              ^^ punctuation.section.embedded.end.liquid
+    }
+
+    @supports ({% if true %} color: {{color}} {% endif %} ) { {% if %} }
+|              ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|                                   ^^^^^^^^^ meta.interpolation.liquid
+|                                             ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|                                                             ^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+
+    {% endif %}
+|   ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|   ^^ punctuation.section.embedded.begin.liquid
+|      ^^^^^ keyword.control.conditional.end.liquid
+|            ^^ punctuation.section.embedded.end.liquid
+
     hr {
         {% if true %}
 |       ^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.embedded.liquid source.liquid meta.statement.liquid

--- a/tests/syntax_test_liquid.liquid.html
+++ b/tests/syntax_test_liquid.liquid.html
@@ -37,7 +37,7 @@
 |^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
 |^ punctuation.section.embedded.begin.liquid
 |  ^^ keyword.control.conditional.if.liquid
-|     ^^^^ constant.language.boolean.liquid
+|     ^^^^ constant.language.boolean.true.liquid
 |          ^^ punctuation.section.embedded.end.liquid
 
 A Paragraph {{var}}
@@ -91,7 +91,7 @@ A Paragraph {{var}}
   == true
 |^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
 | ^^ keyword.operator.assignment.liquid
-|    ^^^^ constant.language.boolean.liquid
+|    ^^^^ constant.language.boolean.true.liquid
 -%}
 
 {% case handle %}
@@ -607,6 +607,13 @@ div {
  --- Test Objects
  -->
 
+  {{ false true }}
+| ^^^^^^^^^^^^^^^^ meta.interpolation.liquid
+| ^^ punctuation.section.interpolation.begin.liquid
+|    ^^^^^ constant.language.boolean.false.liquid
+|          ^^^^ constant.language.boolean.true.liquid
+|               ^^ punctuation.section.interpolation.end.liquid
+
   {{ blank empty nil null }}
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.liquid
 | ^^ punctuation.section.interpolation.begin.liquid
@@ -714,7 +721,7 @@ div {
 |       ^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.embedded.liquid source.liquid meta.statement.liquid
 |       ^^ punctuation.section.embedded.begin.liquid
 |          ^^ keyword.control.conditional.if.liquid
-|             ^^^^ constant.language.boolean.liquid
+|             ^^^^ constant.language.boolean.true.liquid
 |                  ^^ punctuation.section.embedded.end.liquid
 ;       {{prop}}: {{value}};
 |       ^^^^^^^^ meta.interpolation.liquid

--- a/tests/syntax_test_liquid.liquid.html
+++ b/tests/syntax_test_liquid.liquid.html
@@ -750,6 +750,21 @@ div {
 |              ^^ punctuation.section.embedded.end.liquid
     }
 
+    @layer {
+      {% if true %}
+|     ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^ keyword.control.conditional.if.liquid
+|           ^^^^ constant.language.boolean.true.liquid
+|                ^^ punctuation.section.embedded.end.liquid
+
+      {% endif %}
+|     ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^^^^ keyword.control.conditional.end.liquid
+|              ^^ punctuation.section.embedded.end.liquid
+    }
+
     @supports ({% if true %} color: {{color}} {% endif %} ) { {% if %} }
 |              ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
 |                                   ^^^^^^^^^ meta.interpolation.liquid

--- a/tests/syntax_test_liquid.md
+++ b/tests/syntax_test_liquid.md
@@ -10,7 +10,7 @@
 |^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
 |^ punctuation.section.embedded.begin.liquid
 |  ^^ keyword.control.conditional.if.liquid
-|     ^^^^ constant.language.boolean.liquid
+|     ^^^^ constant.language.boolean.true.liquid
 |          ^^ punctuation.section.embedded.end.liquid
 
 A Paragraph {{var}}
@@ -563,6 +563,13 @@ div {
  --- Test Objects
  -->
 
+  {{ false true }}
+| ^^^^^^^^^^^^^^^^ meta.interpolation.liquid
+| ^^ punctuation.section.interpolation.begin.liquid
+|    ^^^^^ constant.language.boolean.false.liquid
+|          ^^^^ constant.language.boolean.true.liquid
+|               ^^ punctuation.section.interpolation.end.liquid
+
   {{ blank empty nil null }}
 | ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.liquid
 | ^^ punctuation.section.interpolation.begin.liquid
@@ -658,7 +665,7 @@ div {
 |       ^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.embedded.liquid source.liquid meta.statement.liquid
 |       ^^ punctuation.section.embedded.begin.liquid
 |          ^^ keyword.control.conditional.if.liquid
-|             ^^^^ constant.language.boolean.liquid
+|             ^^^^ constant.language.boolean.true.liquid
 |                  ^^ punctuation.section.embedded.end.liquid
 ;       font-{{family}}: "{{font}}";
 |            ^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.interpolation.liquid

--- a/tests/syntax_test_liquid.md
+++ b/tests/syntax_test_liquid.md
@@ -660,6 +660,56 @@ div {
  -->
 
 <style>
+
+    {% if true %}
+|   ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|   ^^ punctuation.section.embedded.begin.liquid
+|      ^^ keyword.control.conditional.if.liquid
+|         ^^^^ constant.language.boolean.true.liquid
+|              ^^ punctuation.section.embedded.end.liquid
+
+    @keyframes {
+      {% if true %}
+|     ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^ keyword.control.conditional.if.liquid
+|           ^^^^ constant.language.boolean.true.liquid
+|                ^^ punctuation.section.embedded.end.liquid
+        
+      {% endif %}
+|     ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^^^^ keyword.control.conditional.end.liquid
+|              ^^ punctuation.section.embedded.end.liquid
+    }
+
+    @layer {
+      {% if true %}
+|     ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^ keyword.control.conditional.if.liquid
+|           ^^^^ constant.language.boolean.true.liquid
+|                ^^ punctuation.section.embedded.end.liquid
+
+      {% endif %}
+|     ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|     ^^ punctuation.section.embedded.begin.liquid
+|        ^^^^^ keyword.control.conditional.end.liquid
+|              ^^ punctuation.section.embedded.end.liquid
+    }
+
+    @supports ({% if true %} color: {{color}} {% endif %} ) { {% if %} }
+|              ^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|                                   ^^^^^^^^^ meta.interpolation.liquid
+|                                             ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|                                                             ^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+
+    {% endif %}
+|   ^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|   ^^ punctuation.section.embedded.begin.liquid
+|      ^^^^^ keyword.control.conditional.end.liquid
+|            ^^ punctuation.section.embedded.end.liquid
+
     hr {
         {% if true %}
 |       ^^^^^^^^^^^^^ source.css.embedded.html meta.property-list.css meta.block.css meta.embedded.liquid source.liquid meta.statement.liquid


### PR DESCRIPTION
I’m not sure this is the right way to do this but have been running this change locally for a few days and it seems ok.

The issue this tries to fix is that when Liquid interpolations happen outside CSS rules, they’re not properly highlighted.

Before – compare with JavaScript:

![CleanShot 2025-02-28 at 09 39 55@2x](https://github.com/user-attachments/assets/da4b030c-8ed8-451d-abfb-7ef55e477960)

After:

![CleanShot 2025-02-28 at 09 40 05@2x](https://github.com/user-attachments/assets/81c7b19f-c041-4571-83b6-999c32b386f8)

One reason I’m slightly suspicious of this change is that the JavaScript interpolations seem to work fine without an additional context.

<details>
<summary>Test code</summary>

```liquid
{% liquid
  assign foo = 'bar'
%}

<script>
  {% liquid
    assign foo = 'bar'
  %}

  window.settings = {
    fontSize: '{{ settings.font_size | append: 'px' }}';
    letterSpacing: '{{ settings.letter_spacing | append: 'px' }}';
  }
</script>

{% style %}
  {% liquid
    assign foo = 'bar'
  %}

  body {
    font-size: {{ settings.font_size | append: 'px' }};
    letter-spacing: {{ settings.letter_spacing | append: 'px' }};
  }
{% endstyle %}

<style>
  {% liquid
    assign foo = 'bar'
  %}

  body {
    font-size: {{ settings.font_size | append: 'px' }};
    letter-spacing: {{ settings.letter_spacing | append: 'px' }};
  }
</style>

```
</details>