### PR TITLE
Add support for the `{% stylesheet %}` Liquid tag

### DIFF
--- a/Syntaxes/Liquid.sublime-syntax
+++ b/Syntaxes/Liquid.sublime-syntax
@@ -30,6 +30,7 @@ contexts:
     - include: liquid-schema-tags
     - include: liquid-javascript-tags
     - include: liquid-style-tags
+    - include: liquid-stylesheet-tags
     - include: liquid-raw-tags
     - include: liquid-statement-tags
 
@@ -127,12 +128,11 @@ contexts:
         2: keyword.declaration.schema.liquid
         3: punctuation.section.embedded.end.liquid
 
-###[ LIQUID STYLE AND STYLESHEET TAGS ]#######################################
+###[ LIQUID STYLE TAGS ]######################################################
 
   liquid-style-tags:
     # https://shopify.dev/api/liquid/tags/theme-tags#style
-    # https://shopify.dev/docs/api/liquid/tags/theme-tags#stylesheet
-    - match: ({%-?)\s*(style|stylesheet)\s*(-?%})
+    - match: ({%-?)\s*(style)\s*(-?%})
       scope: meta.embedded.liquid source.liquid meta.statement.liquid
       captures:
         1: punctuation.section.embedded.begin.liquid
@@ -140,7 +140,26 @@ contexts:
         3: punctuation.section.embedded.end.liquid
       embed: scope:source.css.liquid
       embed_scope: source.css.embedded.liquid
-      escape: ({%-?)\s*(end\2)\s*(-?%})
+      escape: ({%-?)\s*(endstyle)\s*(-?%})
+      escape_captures:
+        0: meta.embedded.liquid source.liquid meta.statement.liquid
+        1: punctuation.section.embedded.begin.liquid
+        2: keyword.declaration.raw.liquid
+        3: punctuation.section.embedded.end.liquid
+
+###[ LIQUID STYLESHEET TAGS ]#################################################
+
+  liquid-stylesheet-tags:
+    # https://shopify.dev/docs/api/liquid/tags/theme-tags#stylesheet
+    - match: ({%-?)\s*(stylesheet)\s*(-?%})
+      scope: meta.embedded.liquid source.liquid meta.statement.liquid
+      captures:
+        1: punctuation.section.embedded.begin.liquid
+        2: keyword.declaration.raw.liquid
+        3: punctuation.section.embedded.end.liquid
+      embed: scope:source.css
+      embed_scope: source.css.embedded.liquid
+      escape: ({%-?)\s*(endstylesheet)\s*(-?%})
       escape_captures:
         0: meta.embedded.liquid source.liquid meta.statement.liquid
         1: punctuation.section.embedded.begin.liquid

--- a/Syntaxes/Liquid.sublime-syntax
+++ b/Syntaxes/Liquid.sublime-syntax
@@ -127,11 +127,12 @@ contexts:
         2: keyword.declaration.schema.liquid
         3: punctuation.section.embedded.end.liquid
 
-###[ LIQUID STYLE TAGS ]#######################################################
+###[ LIQUID STYLE AND STYLESHEET TAGS ]#######################################
 
   liquid-style-tags:
     # https://shopify.dev/api/liquid/tags/theme-tags#style
-    - match: ({%-?)\s*(style)\s*(-?%})
+    # https://shopify.dev/docs/api/liquid/tags/theme-tags#stylesheet
+    - match: ({%-?)\s*(style|stylesheet)\s*(-?%})
       scope: meta.embedded.liquid source.liquid meta.statement.liquid
       captures:
         1: punctuation.section.embedded.begin.liquid
@@ -139,7 +140,7 @@ contexts:
         3: punctuation.section.embedded.end.liquid
       embed: scope:source.css.liquid
       embed_scope: source.css.embedded.liquid
-      escape: ({%-?)\s*(endstyle)\s*(-?%})
+      escape: ({%-?)\s*(end\2)\s*(-?%})
       escape_captures:
         0: meta.embedded.liquid source.liquid meta.statement.liquid
         1: punctuation.section.embedded.begin.liquid

--- a/tests/syntax_test_liquid.liquid.html
+++ b/tests/syntax_test_liquid.liquid.html
@@ -602,17 +602,7 @@ div {
 |             ^^ punctuation.section.embedded.end.liquid
 
 div {
-    font-{{family}}: "{{font}}";
-|        ^^^^^^^^^^ meta.property-list.css meta.block.css meta.interpolation.liquid
-|        ^^ punctuation.section.interpolation.begin.liquid
-|          ^^^^^^ variable.other.liquid
-|                ^^ punctuation.section.interpolation.end.liquid
-|                    ^ meta.string.css string.quoted.double.css punctuation.definition.string.begin.css
-|                     ^^^^^^^^ meta.property-list.css meta.block.css meta.property-value.css meta.string.css meta.interpolation.liquid
-|                     ^^ punctuation.section.interpolation.begin.liquid
-|                       ^^^^ variable.other.liquid
-|                           ^^ punctuation.section.interpolation.end.liquid
-|                             ^ meta.string.css string.quoted.double.css punctuation.definition.string.end.css
+    display: none;
 }
 
 {% endstylesheet %}

--- a/tests/syntax_test_liquid.liquid.html
+++ b/tests/syntax_test_liquid.liquid.html
@@ -594,6 +594,34 @@ div {
 |  ^^^^^^^^ keyword.declaration.raw.liquid
 |           ^^ punctuation.section.embedded.end.liquid
 
+{% stylesheet %}
+| <- meta.embedded.liquid source.liquid meta.statement.liquid punctuation.section.embedded.begin.liquid
+|^^^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|^ punctuation.section.embedded.begin.liquid
+|  ^^^^^^^^^^ keyword.declaration.raw.liquid
+|             ^^ punctuation.section.embedded.end.liquid
+
+div {
+    font-{{family}}: "{{font}}";
+|        ^^^^^^^^^^ meta.property-list.css meta.block.css meta.interpolation.liquid
+|        ^^ punctuation.section.interpolation.begin.liquid
+|          ^^^^^^ variable.other.liquid
+|                ^^ punctuation.section.interpolation.end.liquid
+|                    ^ meta.string.css string.quoted.double.css punctuation.definition.string.begin.css
+|                     ^^^^^^^^ meta.property-list.css meta.block.css meta.property-value.css meta.string.css meta.interpolation.liquid
+|                     ^^ punctuation.section.interpolation.begin.liquid
+|                       ^^^^ variable.other.liquid
+|                           ^^ punctuation.section.interpolation.end.liquid
+|                             ^ meta.string.css string.quoted.double.css punctuation.definition.string.end.css
+}
+
+{% endstylesheet %}
+| <- meta.embedded.liquid source.liquid meta.statement.liquid punctuation.section.embedded.begin.liquid
+|^^^^^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid
+|^ punctuation.section.embedded.begin.liquid
+|  ^^^^^^^^^^^^^ keyword.declaration.raw.liquid
+|                ^^ punctuation.section.embedded.end.liquid
+
 {% plugin "foo" %}
 | <- meta.embedded.liquid source.liquid meta.statement.liquid punctuation.section.embedded.begin.liquid
 |^^^^^^^^^^^^^^^^^ meta.embedded.liquid source.liquid meta.statement.liquid


### PR DESCRIPTION
Adds support for the [`{% stylesheet %}`](https://shopify.dev/docs/api/liquid/tags/theme-tags#stylesheet) tag.

~~From a syntax point of view, it’s identical to the `{% style %}` tag. The difference is on the platform level: the contents of `{% stylesheet %}` tags are compiled into a CSS file.~~

Update: My bad, `{% stylesheet %}` tags cannot contain Liquid as per the doc I linked above. I’ve updated the syntax to reflect this.